### PR TITLE
Clear dob components instead of setting dobOrAge to age

### DIFF
--- a/controllers/helpers/suggestionHelpers.js
+++ b/controllers/helpers/suggestionHelpers.js
@@ -88,8 +88,16 @@ const searchSuggestions = {
         suggest: dobToAgeRange
     }, {
         type: 'convertToAgeRange',
-        term: 'dobOrAge',
-        suggest: val => 'age'
+        term: 'dobDay',
+        suggest: val => ''
+    }, {
+        type: 'convertToAgeRange',
+        term: 'dobMonth',
+        suggest: val => ''
+    }, {
+        type: 'convertToAgeRange',
+        term: 'dobYear',
+        suggest: val => ''
     }]
 };
 

--- a/controllers/searchController.js
+++ b/controllers/searchController.js
@@ -118,8 +118,7 @@ exports.getSuggestions = function(req, res) {
     return res.render('search/suggestions', {
         content: content.view.suggestions,
         returnQuery: retainUrlQuery(req.url),
-        suggestions: getSearchSuggestions(req.session.userInput),
-        searchTerms: req.session.searchTerms             
+        suggestions: getSearchSuggestions(req.session.userInput)
     });
 };
 
@@ -130,7 +129,7 @@ exports.getSuggestion = function(req, res) {
 
 function parseResultsPageData(req, rowCount, data, page, error) {
     const searchedFor = getUserInput(req.session.userInput);
-  
+
     return {
         content: {
             title: 'HPA Prisoner Search'
@@ -144,7 +143,7 @@ function parseResultsPageData(req, rowCount, data, page, error) {
         formContents: searchedFor,
         usePlaceholder: Object.keys(searchedFor).length === 0,
         idSearch: availableSearchOptions.identifier.fields.includes(Object.keys(searchedFor)[0]),
-		    suggestions: getSearchSuggestions(req.session.userInput),
+		suggestions: getSearchSuggestions(req.session.userInput),
         moment: require('moment'),
         setCase: require('case')
     };

--- a/test/controllers/helpers/suggestionHelpersTest.js
+++ b/test/controllers/helpers/suggestionHelpersTest.js
@@ -59,11 +59,19 @@ describe('suggestionHelpers', () => {
         value: '28-32'
     };
 
-    const suggestChangeDobToAge = {
+    const suggestClearDobFields = [{
         type: 'convertToAgeRange',
-        term: 'dobOrAge',
-        value: 'age'
-    };
+        term: 'dobDay',
+        value: ''
+    },{
+        type: 'convertToAgeRange',
+        term: 'dobMonth',
+        value: ''
+    },{
+        type: 'convertToAgeRange',
+        term: 'dobYear',
+        value: ''
+    }];
 
     describe('getSearchSuggestion', () => {
 
@@ -114,7 +122,7 @@ describe('suggestionHelpers', () => {
         it('should suggest changing dob to age range', () => {
 
             const userInput = {dobOrAge: 'dob', dobDay: '01', dobMonth: '08', dobYear: '1987'};
-            const expected = {dob: [suggestConvertToAgeRange, suggestChangeDobToAge]};
+            const expected = {dob: [suggestConvertToAgeRange].concat(suggestClearDobFields)};
 
             expect(getSearchSuggestions(userInput)).to.eql(expected);
         });


### PR DESCRIPTION
Used to add {'dobOrAge': 'age:} to switch to age from dob. Instead now have to clear the dob terms.

UserInput starts as 
{ forename: 'Robin',
  surname: 'Banks%',
  dobDay: '05',
  dobMonth: '05',
  dobYear: '1987',
  page: 1 }

Gets changed to:
{ forename: 'Robin',
  surname: 'Banks%',
  dobDay: '',
  dobMonth: '',
  dobYear: '',
  page: 1,
  age: '28-32' }
